### PR TITLE
Fix playwright version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "vite": "5.0.12"
   },
   "devDependencies": {
-    "@playwright/test": "^1.41.0",
+    "@playwright/test": "1.41.0",
     "@types/node": "^20.11.1",
     "prettier": "^3.2.3"
   }


### PR DESCRIPTION
We cannot automatically update playwright via dependabot, as it need to match the playwright dockerfile version