### PR TITLE
chore: pnpm audit fix transient CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,12 +16,12 @@
   },
   "dependencies": {
     "react": "18.3.1",
-    "react-dom": ">=18.0.0 < 19",
-    "swagger-ui": "^5.18.3"
+    "react-dom": "^18.3.1",
+    "swagger-ui": "^5.32.11"
   },
   "devDependencies": {
     "@playwright/test": "1.62.1",
-    "prettier": "^3.0.3",
-    "vite": "^8.0.0"
+    "prettier": "^3.9.6",
+    "vite": "^8.2.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,20 +12,20 @@ importers:
         specifier: 18.3.1
         version: 18.3.1
       react-dom:
-        specifier: '>=18.0.0 < 19'
+        specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       swagger-ui:
-        specifier: ^5.18.3
+        specifier: ^5.32.11
         version: 5.32.11(debug@4.4.3)
     devDependencies:
       '@playwright/test':
         specifier: 1.62.1
         version: 1.62.1
       prettier:
-        specifier: ^3.0.3
+        specifier: ^3.9.6
         version: 3.9.6
       vite:
-        specifier: ^8.0.0
+        specifier: ^8.2.0
         version: 8.2.0
 
 packages:
@@ -343,8 +343,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   buffer@6.0.3:
@@ -584,6 +584,10 @@ packages:
 
   js-yaml@4.3.0:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+    hasBin: true
+
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   lightningcss-android-arm64@1.33.0:
@@ -1634,7 +1638,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -1861,6 +1865,10 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  js-yaml@4.3.1:
+    dependencies:
+      argparse: 2.0.1
+
   lightningcss-android-arm64@1.33.0:
     optional: true
 
@@ -1937,7 +1945,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   ms@2.1.3: {}
 
@@ -2174,7 +2182,7 @@ snapshots:
       '@swaggerexpert/cookie': 2.0.2
       deepmerge: 4.3.1
       fast-json-patch: 3.1.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       neotraverse: 0.6.18
       node-abort-controller: 3.1.1
       openapi-path-templating: 2.2.1


### PR DESCRIPTION
## Summary
- Baseline audit status: 2 CVEs
- Final audit status: 1 CVE
- Files changed: package.json and pnpm-lock.yaml
- Remaining unresolved CVEs:
  - GHSA-5p4m-2wfm-xmqj: js-yaml